### PR TITLE
Query the correct package name for theme customization

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <queries>
         <!-- Specific intents Wallpaper picker query for -->
         <!-- Package for theme stub -->
-        <package android:name="com.android.customization.themes" />
+        <package android:name="com.android.customization.stub" />
         <!-- Intent filter with action SET_WALLPAPER -->
         <intent>
             <action android:name="android.intent.action.SET_WALLPAPER" />


### PR DESCRIPTION
There's no need to mark the Default Themes app force queryable, as it's only needed to be queried by this app to display theming options. Merge with https://github.com/GrapheneOS/platform_themes/pull/2