### PR TITLE
Move color options resources from platform_themes to ThemePicker

### DIFF
--- a/themes/res/values/color-bundles.xml
+++ b/themes/res/values/color-bundles.xml
@@ -16,13 +16,24 @@
   -->
 <resources>
     <array name="color_bundles">
-        <item>monochromatic</item>
-        <item>rainbow1</item>
-        <item>rainbow2</item>
-        <item>rainbow3</item>
-        <item>rainbow4</item>
-        <item>rainbow5</item>
-        <item>rainbow6</item>
-        <item>rainbow7</item>
+        <item>default</item>
+        <item>dark_green</item>
+        <item>brown</item>
+        <item>dark_magenta</item>
+
+        <item>light_cyan</item>
+        <item>light_green</item>
+        <item>light_yellow</item>
+        <item>light_magenta</item>
+
+        <item>pink_red</item>
+        <item>light_brown</item>
+        <item>cyan_blue</item>
+        <item>blue_magenta</item>
+
+        <item>neon_lilac</item>
+        <item>magenta</item>
+        <item>yellow</item>
+        <item>green</item>
     </array>
 </resources>

--- a/themes/res/values/colors_ext.xml
+++ b/themes/res/values/colors_ext.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="color_primary_default">#ffffff</color>
+    <color name="color_secondary_default">#1565C0</color>
+
+    <color name="color_primary_dark_green">#0a8758</color>
+    <color name="color_secondary_dark_green">#0a8758</color>
+
+    <color name="color_primary_dark_magenta">#746bc1</color>
+    <color name="color_secondary_dark_magenta">#746bc1</color>
+
+    <color name="color_primary_brown">#a66800</color>
+    <color name="color_secondary_brown">#a66800</color>
+
+    <color name="color_primary_light_yellow">#ffeeb2</color>
+    <color name="color_secondary_light_yellow">#ffeeb2</color>
+
+    <color name="color_primary_light_green">#ccee99</color>
+    <color name="color_secondary_light_green">#ccee99</color>
+
+    <color name="color_primary_light_cyan">#b1ebff</color>
+    <color name="color_secondary_light_cyan">#b1ebff</color>
+
+    <color name="color_primary_light_magenta">#ebdcff</color>
+    <color name="color_secondary_light_magenta">#ebdcff</color>
+
+    <color name="color_primary_pink_red">#ffb2b5</color>
+    <color name="color_secondary_pink_red">#ffb2b5</color>
+
+    <color name="color_primary_light_brown">#ffb868</color>
+    <color name="color_secondary_light_brown">#ffb868</color>
+
+    <color name="color_primary_yellow">#e9c44a</color>
+    <color name="color_secondary_yellow">#e9c44a</color>
+
+    <color name="color_primary_green">#baf293</color>
+    <color name="color_secondary_green">#baf293</color>
+
+    <color name="color_primary_cyan_blue">#96cbff</color>
+    <color name="color_secondary_cyan_blue">#96cbff</color>
+
+    <color name="color_primary_blue_magenta">#cbbfff</color>
+    <color name="color_secondary_blue_magenta">#cbbfff</color>
+
+    <color name="color_primary_magenta">#f5acfb</color>
+    <color name="color_secondary_magenta">#f5acfb</color>
+
+    <color name="color_primary_neon_lilac">#A264A0</color>
+    <color name="color_secondary_neon_lilac">#533352</color>
+</resources>

--- a/themes/res/values/strings_ext.xml
+++ b/themes/res/values/strings_ext.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="bundle_name_default">GrapheneOS Default</string>
+    <string name="bundle_name_dark_green">Dark Green</string>
+    <string name="bundle_name_dark_magenta">Dark Magenta</string>
+    <string name="bundle_name_brown">Brown</string>
+
+    <string name="color_style_default">TONAL_SPOT</string>
+    <string name="color_style_dark_green">TONAL_SPOT</string>
+    <string name="color_style_dark_magenta">TONAL_SPOT</string>
+    <string name="color_style_brown">TONAL_SPOT</string>
+
+    <string name="bundle_name_light_yellow">Yellow</string>
+    <string name="bundle_name_light_green">Light Green</string>
+    <string name="bundle_name_light_cyan">Light Cyan</string>
+    <string name="bundle_name_light_magenta">Light Magenta</string>
+
+    <string name="color_style_light_yellow">SPRITZ</string>
+    <string name="color_style_light_green">SPRITZ</string>
+    <string name="color_style_light_cyan">VIBRANT</string>
+    <string name="color_style_light_magenta">VIBRANT</string>
+
+    <string name="bundle_name_pink_red">Pink Red</string>
+    <string name="bundle_name_light_brown">Light Brown</string>
+    <string name="bundle_name_cyan_blue">Cyan Blue</string>
+    <string name="bundle_name_blue_magenta">Blue Magenta</string>
+
+    <string name="bundle_name_neon_lilac">Neon Lilac</string>
+    <string name="bundle_name_magenta">Magenta</string>
+    <string name="bundle_name_yellow">Yellow</string>
+    <string name="bundle_name_green">Green</string>
+
+    <string name="color_style_pink_red">EXPRESSIVE</string>
+    <string name="color_style_light_brown">EXPRESSIVE</string>
+    <string name="color_style_cyan_blue">RAINBOW</string>
+    <string name="color_style_blue_magenta">RAINBOW</string>
+    <string name="color_style_neon_lilac">FRUIT_SALAD</string>
+    <string name="color_style_magenta">FRUIT_SALAD</string>
+    <string name="color_style_yellow">CONTENT</string>
+    <string name="color_style_green">CONTENT</string>
+
+    <!--possible styles : SPRITZ, TONAL_SPOT, VIBRANT, EXPRESSIVE, RAINBOW, FRUIT_SALAD, CONTENT-->
+</resources>


### PR DESCRIPTION
The changelist merges the color options resources in theming option into the standard AOSP stub package for theme picker.

Merge with:
https://github.com/GrapheneOS/platform_build/pull/36
https://github.com/GrapheneOS/platform_manifest/pull/22
https://github.com/GrapheneOS/script/pull/37