### PR TITLE
fixup! Use GrapheneOS apps to preview icons

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -29,8 +29,7 @@
         <package android:name="com.android.settings"/>
         <package android:name="com.android.systemui"/>
         <!-- Package of camera for icon shape -->
-        <package android:name="com.android.camera2" />
-        <package android:name="com.google.android.desktop.camera" />
+        <package android:name="app.grapheneos.camera" />
 
         <!-- Specific intents Wallpaper picker query for -->
         <!-- Package for theme stub -->

--- a/res_override/values/override.xml
+++ b/res_override/values/override.xml
@@ -37,11 +37,11 @@
         <item>com.android.deskclock</item>
         <item>com.android.messaging</item>
         <item>com.android.settings</item>
-        <item>org.chromium.chrome</item>
-        <item>com.android.camera2</item>
+        <item>app.vanadium.browser</item>
+        <item>app.grapheneos.camera</item>
         <item>com.android.contacts</item>
     </array>
 
     <!-- Package name of the Camera app to be used when previewing icon shape and theme -->
-    <string name="camera_package" translatable="false">com.android.camera2</string>
+    <string name="camera_package" translatable="false">app.grapheneos.camera</string>
 </resources>


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8186

Note that app.vanadium.browser, Messaging, Deskclock, Contacts appear to onyl be used in a stale array. Camera and Settings appear to still be used.